### PR TITLE
npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+libs/
+test/
+docs/
+.eslintrc
+.npmignore
+.travis.yml
+Makefile
+TODO

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ Alternatively, download/clone this repository and add `minipdf.js` and `pdfform.
 
 Simply call `transform` with the PDF file contents and the fields.
 
-	<!-- download from https://raw.githubusercontent.com/phihag/pdfform.js/dist/dist/pdfform.minipdf.dist.js -->
-    <script src="downloaded/pdfform.minipdf.dist.js"></script>
-    <script>
-    var pdf_buf = ...; // load PDF into an ArrayBuffer, for example via XHR (see demo)
-    var fields = {
-    	'fieldname': ['value for fieldname[0]', 'value for fieldname[1]'],
-    };
-    var out_buf = pdfform().transform(pdf_buf, fields);
-    // Do something with the resulting PDF file in out_buf
-    </script>
+```html
+<!-- download from https://raw.githubusercontent.com/phihag/pdfform.js/dist/dist/pdfform.minipdf.dist.js -->
+<script src="downloaded/pdfform.minipdf.dist.js"></script>
+<script>
+var pdf_buf = ...; // load PDF into an ArrayBuffer, for example via XHR (see demo)
+var fields = {
+    'fieldname': ['value for fieldname[0]', 'value for fieldname[1]'],
+};
+var out_buf = pdfform().transform(pdf_buf, fields);
+// Do something with the resulting PDF file in out_buf
+</script>
+```
 
 There is also a `list_fields` function which allows you to list all available fields and their types.
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 generate appearances
-set up proper npm publishing
 automatic releasing
 find a way to get PDFDocument etc. references with native pdf.js
 	WorkerMessageHandler.createDocumentHandler.? -> localPDFManager -> PDFDocument

--- a/package.json
+++ b/package.json
@@ -1,23 +1,27 @@
 {
-	"name": "pdfform.js",
-	"author": "Philipp Hagemeister <phihag@phihag.de>",
-	"description": "Fill out PDF forms in pure JavaScript",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/phihag/pdfform.js.git"
-	},
-	"scripts": {
-		"test": "mocha test/"
-	},
-	"dependencies": {
-		"xmldom": "*",
-		"text-encoding": "*"
-	},
-	"devDependencies": {
-		"mocha": "*",
-		"async": "*",
-		"jshint": "*",
-		"eslint": "*"
-	},
-	"version": "1.0.1"
+  "name": "pdfform.js",
+  "author": "Philipp Hagemeister <phihag@phihag.de>",
+  "description": "Fill out PDF forms in pure JavaScript",
+  "main": "pdfform.js",
+  "browser": "dist/pdfform.minipdf.dist.js",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/phihag/pdfform.js.git"
+  },
+  "scripts": {
+    "test": "mocha test/",
+    "prepublishOnly": "make clean_dist && make lint && make test && make dist"
+  },
+  "dependencies": {
+    "xmldom": "*",
+    "text-encoding": "*"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "async": "*",
+    "jshint": "*",
+    "eslint": "*"
+  },
+  "version": "1.0.1"
 }


### PR DESCRIPTION
This PR turns `pdfform.js` into a usable npm package.

- Changes indentation of `package.json` to 2 spaces (npm will always indent this file to 2 spaces)
- Add `main` and `browser` field (the latter is a hint for webpack, rollup or unpkg)
- Add `license` field
- Ignore dev related files when creating the package (can be tested with `npm pack`)
- Wrap example in `README` in a valid markdown code-block. This gives us nice syntax highlighting here on github and [npmjs.com](https://www.npmjs.com/).

When the package is published `unpkg` could be used as a cdn for the example in the `README`. That way it can be easily included in `jsfiddle`, `codepen` or users can simply copy & paste the snippet and have a working example.

Publish steps:

1. make sure `npm >= 5` is installed (older versions use the deprecated `prepublish` script)
2. Update `version` in `package.json`
3. run `npm publish` (this obviously requires a valid [npm login](https://docs.npmjs.com/getting-started/publishing-npm-packages))