### PR TITLE
Handle PDF forms that are rendered differently

### DIFF
--- a/pdfform.js
+++ b/pdfform.js
@@ -308,7 +308,10 @@ function visit_acroform_fields(doc, callback) {
 				to_visit.push.apply(to_visit, n.map.Kids);
 			} else if (n.map && n.map.Type && n.map.Type.name == 'Annot' && n.map.T) {
 				callback(n);
-			}
+			//Handles case where PDF renders form in a different way
+			} else if (n.map && n.map.FT && (n.map.FT.name === "Btn" || n.map.FT.name === 'Tx' || n.map.FT.name === 'Ch')&& n.map.T) {
+                    		callback(n)
+                	}
 		}
 	} else {
 		// No AcroForm? Look in the pages themselves


### PR DESCRIPTION
Online PDF editors can render form properties differently from Acrobat, which was causing issues for me where the list_fields() function wasn't working, so I investigated and handled an edge case to detect those form fields as well.