### PR TITLE
Latest Acrobat breaking change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ test:
 
 dist: clean_dist
 	mkdir -p dist
-	node_modules/.bin/uglifyjs -b ascii_only=true,beautify=false libs/pako.min.js minipdf.js pdfform.js -o dist/pdfform.minipdf.dist.js
-	node_modules/.bin/uglifyjs -b ascii_only=true,beautify=false libs/pako.min.js customlibs/pdf.worker.js minipdf_js.js pdfform.js -o dist/pdfform.pdf_js.dist.js
+	node_modules/.bin/uglifyjs -b ascii_only=true,beautify=false minipdf.js pdfform.js -o dist/pdfform.minipdf.dist.js
+	node_modules/.bin/uglifyjs -b ascii_only=true,beautify=false customlibs/pdf.worker.js minipdf_js.js pdfform.js -o dist/pdfform.pdf_js.dist.js
 
 clean: clean_dist
 	rm -rf -- node_modules

--- a/minipdf.js
+++ b/minipdf.js
@@ -499,7 +499,7 @@ PDFReader.prototype = {
 		var offset_length = obj.map.W[1];
 		assert((offset_length >= 1) && (offset_length <= 4));
 		var gen_length = obj.map.W[2];
-		assert((gen_length >= 1) && (gen_length <= 4));
+		assert((gen_length >= 0) && (gen_length <= 4));
 		assert(
 			obj.content.length % (type_length + offset_length + gen_length) === 0,
 			'content is ' + obj.content.length + ' bytes long, each entry is ' + JSON.stringify(obj.map.W));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "mocha": "^5.0.4",
     "uglify-js": "3.x"
   },
-  "version": "1.0.14"
+  "version": "1.0.15"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdfform.js",
+  "name": "@creditiq/pdfform.js",
   "author": "Philipp Hagemeister <phihag@phihag.de>",
   "description": "Fill out PDF forms in pure JavaScript",
   "main": "pdfform.js",
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/phihag/pdfform.js.git"
+    "url": "git://github.com/creditiq/pdfform.js.git"
   },
   "scripts": {
     "test": "mocha test/",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "mocha": "^5.0.4",
     "uglify-js": "3.x"
   },
-  "version": "1.0.15"
+  "version": "1.0.16"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "mocha": "^5.0.4",
     "uglify-js": "3.x"
   },
-  "version": "1.0.17"
+  "version": "1.0.18"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "mocha": "^5.0.4",
     "uglify-js": "3.x"
   },
-  "version": "1.0.16"
+  "version": "1.0.17"
 }


### PR DESCRIPTION
After saving files using version 2021.005.20048 of Acrobat, pdfform.js would no longer be able to parse the form.  This pull request fixes the problem -- hopefully it doesn't cause any others.