### PR TITLE
Update dependency xmldom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfform.js",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,6 +23,11 @@
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.0.tgz",
+      "integrity": "sha512-7wVnF+rKrVDEo1xjzkkidTG0grclaVnX0vKa0z9JSXcEdtftUJjvU33jLGg6SHyvs3eeqEsI7jZ6NxYfRypEEg=="
     },
     "acorn": {
       "version": "6.1.1",
@@ -1086,11 +1091,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "make clean_dist && make lint && make test && make dist"
   },
   "dependencies": {
-    "xmldom": "*",
+    "@xmldom/xmldom": "*",
     "text-encoding": "*",
     "pako": "*"
   },

--- a/pdfform.js
+++ b/pdfform.js
@@ -2,8 +2,8 @@
 
 if (typeof window == 'undefined') {
 	// node.js, load compat libraries
-	var DOMParser = require('xmldom').DOMParser;
-	var XMLSerializer = require('xmldom').XMLSerializer;
+	var DOMParser = require('@xmldom/xmldom').DOMParser;
+	var XMLSerializer = require('@xmldom/xmldom').XMLSerializer;
 	var text_encoding = require('text-encoding');
 	var TextEncoder = text_encoding.TextEncoder;
 	var TextDecoder = text_encoding.TextDecoder;


### PR DESCRIPTION
Switching from package `xmldom` to `@xmldom/xmldom`, which resolves the security issue present in latest xmldom version 0.6.0:
https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q

The reason is that the maintainers were forced to switch to a scoped package since 0.7.0:
 https://github.com/xmldom/xmldom/issues/271

- I used node 12 to run `npm install`.
- I executed `npm run test` on my machine without failure
- I tried to run `npm run prepublishOnly` but it failed in `make test` with one test timing out. After running `make force-install-libs` it fails in the step `make dist` (Makefile line 39), but from the error message it doesn't look like it's an issue related to this PR
- This makes #35 obsolete

I'm one of the xmldom maintainers. Don't hesitate to ask me questions.

https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md